### PR TITLE
chore: revert serializable_tree_type

### DIFF
--- a/src/api/method/get_validity_proof/common.rs
+++ b/src/api/method/get_validity_proof/common.rs
@@ -124,7 +124,7 @@ impl From<GetValidityProofResponse> for GetValidityProofResponseV2 {
                     .merkleTrees
                     .iter()
                     .map(|x| MerkleContextV2 {
-                        tree_type: SerializableTreeType::Unknown,
+                        tree_type: 0,                                            // TODO: check
                         tree: SerializablePubkey::try_from(x.as_str()).unwrap(), // TODO: handle error
                         queue: SerializablePubkey::default(),
                         cpi_context: None,
@@ -273,24 +273,24 @@ pub enum SerializableTreeType {
 }
 
 // from u64
-impl From<u16> for SerializableTreeType {
-    fn from(value: u16) -> Self {
-        match value {
-            0 => SerializableTreeType::Unknown,
-            1 => SerializableTreeType::State,
-            2 => SerializableTreeType::Address,
-            3 => SerializableTreeType::BatchedState,
-            4 => SerializableTreeType::BatchedAddress,
-            _ => panic!("Invalid TreeType"),
-        }
-    }
-}
+// impl From<u16> for SerializableTreeType {
+//     fn from(value: u16) -> Self {
+//         match value {
+//             0 => SerializableTreeType::Unknown,
+//             1 => SerializableTreeType::State,
+//             2 => SerializableTreeType::Address,
+//             3 => SerializableTreeType::BatchedState,
+//             4 => SerializableTreeType::BatchedAddress,
+//             _ => panic!("Invalid TreeType"),
+//         }
+//     }
+// }
 
 #[derive(Serialize, Deserialize, ToSchema, Debug, Clone, Eq, PartialEq)]
 #[serde(rename_all = "camelCase")]
 #[allow(non_snake_case)]
 pub struct MerkleContextV2 {
-    pub tree_type: SerializableTreeType,
+    pub tree_type: u16,
     pub tree: SerializablePubkey,
     // nullifier_queue in legacy trees, output_queue in V2 trees.
     pub queue: SerializablePubkey,

--- a/src/api/method/get_validity_proof/common.rs
+++ b/src/api/method/get_validity_proof/common.rs
@@ -262,7 +262,8 @@ impl From<Option<u64>> for RootIndex {
     }
 }
 
-#[repr(u64)]
+// TODO: Keep in here for API doc generation?
+#[repr(u16)]
 #[derive(Serialize, Deserialize, ToSchema, Debug, PartialEq, Clone, Copy, Eq)]
 pub enum SerializableTreeType {
     State = 1,
@@ -271,20 +272,6 @@ pub enum SerializableTreeType {
     BatchedAddress = 4,
     Unknown = 0, // TODO: remove this
 }
-
-// from u64
-// impl From<u16> for SerializableTreeType {
-//     fn from(value: u16) -> Self {
-//         match value {
-//             0 => SerializableTreeType::Unknown,
-//             1 => SerializableTreeType::State,
-//             2 => SerializableTreeType::Address,
-//             3 => SerializableTreeType::BatchedState,
-//             4 => SerializableTreeType::BatchedAddress,
-//             _ => panic!("Invalid TreeType"),
-//         }
-//     }
-// }
 
 #[derive(Serialize, Deserialize, ToSchema, Debug, Clone, Eq, PartialEq)]
 #[serde(rename_all = "camelCase")]

--- a/src/api/method/get_validity_proof/mod.rs
+++ b/src/api/method/get_validity_proof/mod.rs
@@ -6,7 +6,6 @@ pub use common::{
     CompressedProof, CompressedProofWithContext, CompressedProofWithContextV2, ContextInfo,
     GetValidityProofRequest, GetValidityProofRequestDocumentation, GetValidityProofRequestV2,
     GetValidityProofResponse, GetValidityProofResponseV2, MerkleContextV2, RootIndex,
-    SerializableTreeType,
 };
 pub use v1::get_validity_proof;
 pub use v2::get_validity_proof_v2;

--- a/src/api/method/get_validity_proof/v2.rs
+++ b/src/api/method/get_validity_proof/v2.rs
@@ -114,7 +114,7 @@ pub async fn get_validity_proof_v2(
         v2_response.value.merkle_context.insert(
             index,
             MerkleContextV2 {
-                tree_type: SerializableTreeType::from(account.tree_type as u16),
+                tree_type: account.tree_type as u16,
                 tree: SerializablePubkey::try_from_slice(account.tree.as_slice())
                     .unwrap_or(SerializablePubkey::default()),
                 queue: SerializablePubkey::try_from_slice(account.queue.as_slice())

--- a/src/api/method/get_validity_proof/v2.rs
+++ b/src/api/method/get_validity_proof/v2.rs
@@ -7,7 +7,6 @@ use itertools::Itertools;
 use sea_orm::{DatabaseBackend, DatabaseConnection, Statement, TransactionTrait};
 
 use super::common::{GetValidityProofRequestV2, GetValidityProofResponseV2, MerkleContextV2};
-use crate::api::method::get_validity_proof::SerializableTreeType;
 use crate::common::typedefs::hash::Hash;
 use crate::dao::generated::accounts;
 use sea_orm::{ColumnTrait, ConnectionTrait, EntityTrait, QueryFilter};

--- a/src/api/method/utils.rs
+++ b/src/api/method/utils.rs
@@ -26,7 +26,6 @@ use crate::common::typedefs::hash::Hash;
 use crate::common::typedefs::serializable_pubkey::SerializablePubkey;
 
 use super::super::error::PhotonApiError;
-use crate::api::method::get_validity_proof::SerializableTreeType;
 use crate::dao::generated::accounts::Model;
 use sea_orm_migration::sea_query::Expr;
 

--- a/src/api/method/utils.rs
+++ b/src/api/method/utils.rs
@@ -178,7 +178,7 @@ impl TryFrom<accounts::Model> for AccountWithContext {
                     .map(|index| UnsignedInteger(index as u64)),
                 nullifier: account.nullifier.map(Hash::try_from).transpose()?,
                 tx_hash: account.tx_hash.map(Hash::try_from).transpose()?,
-                tree_type: SerializableTreeType::from(account.tree_type as u16),
+                tree_type: account.tree_type as u16,
             },
         })
     }

--- a/src/common/typedefs/account.rs
+++ b/src/common/typedefs/account.rs
@@ -3,7 +3,7 @@ use super::{
     unsigned_integer::UnsignedInteger,
 };
 use crate::api::error::PhotonApiError;
-use crate::api::method::get_validity_proof::{MerkleContextV2, SerializableTreeType};
+use crate::api::method::get_validity_proof::MerkleContextV2;
 use crate::api::method::utils::parse_decimal;
 use crate::dao::generated::accounts;
 use crate::dao::generated::accounts::Model;

--- a/src/common/typedefs/account.rs
+++ b/src/common/typedefs/account.rs
@@ -127,7 +127,7 @@ impl TryFrom<accounts::Model> for AccountV2 {
             seq: account.seq.map(|seq| UnsignedInteger(seq as u64)),
             prove_by_index: account.in_output_queue,
             merkle_context: MerkleContextV2 {
-                tree_type: SerializableTreeType::from(account.tree_type as u16),
+                tree_type: account.tree_type as u16,
                 tree: account.tree.try_into()?,
                 queue: account.queue.clone().try_into()?,
                 cpi_context: None,
@@ -162,7 +162,7 @@ pub struct AccountContext {
     // Legacy: None
     // Batched: None if inserted into output queue or inserted in tree from output queue, else Some(nullifier)
     pub tx_hash: Option<Hash>,
-    pub tree_type: SerializableTreeType,
+    pub tree_type: u16,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, ToSchema)]
@@ -221,7 +221,7 @@ impl AccountWithContext {
                 nullifier_queue_index: nullifier_queue_index.map(UnsignedInteger),
                 nullifier,
                 tx_hash: None,
-                tree_type: SerializableTreeType::from(tree_type as u16),
+                tree_type: tree_type as u16,
             },
         }
     }

--- a/src/openapi/mod.rs
+++ b/src/openapi/mod.rs
@@ -25,7 +25,7 @@ use crate::api::method::get_transaction_with_compression_info::{
 };
 use crate::api::method::get_validity_proof::{
     CompressedProof, CompressedProofWithContext, CompressedProofWithContextV2, ContextInfo,
-    MerkleContextV2, RootIndex, SerializableTreeType,
+    MerkleContextV2, RootIndex,
 };
 use crate::api::method::utils::Context;
 use crate::api::method::utils::Limit;
@@ -134,7 +134,6 @@ const JSON_CONTENT_TYPE: &str = "application/json";
     TokenBalanceListV2,
     MerkleContextV2,
     ContextInfo,
-    SerializableTreeType
 )))]
 struct ApiDoc;
 


### PR DESCRIPTION
## Overview

-   dealing with enums strings in client is more pain that I thought, so best to just keep as is imo.
cc  @sergeytimoshin 
