### PR TITLE
chore: consistent `tree` field in v2 endpoints

### DIFF
--- a/src/api/method/get_compressed_account_proof/v2.rs
+++ b/src/api/method/get_compressed_account_proof/v2.rs
@@ -1,5 +1,5 @@
 use crate::api::error::PhotonApiError;
-use crate::api::method::get_validity_proof::ContextInfo;
+use crate::api::method::get_validity_proof::TreeContextInfo;
 use crate::api::method::utils::HashRequest;
 use crate::common::typedefs::context::Context;
 use crate::common::typedefs::hash::Hash;
@@ -33,7 +33,7 @@ pub struct GetCompressedAccountProofResponseValueV2 {
     pub hash: Hash,
     pub root_seq: u64,
     pub prove_by_index: bool,
-    pub context: ContextInfo,
+    pub tree_context: TreeContextInfo,
 }
 
 impl From<MerkleProofWithContext> for GetCompressedAccountProofResponseValueV2 {
@@ -46,9 +46,9 @@ impl From<MerkleProofWithContext> for GetCompressedAccountProofResponseValueV2 {
             root_seq: proof.root_seq,
             prove_by_index: false,
             // Default values to be overridden as needed
-            context: ContextInfo {
+            tree_context: TreeContextInfo {
                 tree_type: 0,
-                merkle_tree: proof.merkle_tree,
+                tree: proof.merkle_tree,
                 queue: Default::default(),
                 cpi_context: None,
             },
@@ -127,8 +127,8 @@ pub async fn get_compressed_account_proof_v2(
 
     // Enrich with account data if available
     if let Some(account) = account {
-        result.context.tree_type = account.tree_type as u16;
-        result.context.queue = SerializablePubkey::try_from(account.queue)?;
+        result.tree_context.tree_type = account.tree_type as u16;
+        result.tree_context.queue = SerializablePubkey::try_from(account.queue)?;
     }
 
     let response = GetCompressedAccountProofResponseV2 {

--- a/src/api/method/get_multiple_compressed_account_proofs/v2.rs
+++ b/src/api/method/get_multiple_compressed_account_proofs/v2.rs
@@ -1,7 +1,7 @@
 use crate::api::error::PhotonApiError;
 use crate::api::method::get_compressed_account_proof::GetCompressedAccountProofResponseValueV2;
 use crate::api::method::get_multiple_compressed_account_proofs::HashList;
-use crate::api::method::get_validity_proof::ContextInfo;
+use crate::api::method::get_validity_proof::TreeContextInfo;
 use crate::api::method::utils::PAGE_LIMIT;
 use crate::common::typedefs::context::Context;
 use crate::common::typedefs::hash::Hash;
@@ -145,9 +145,9 @@ pub async fn get_multiple_compressed_account_proofs_v2(
     // Enrich with account data
     for value in &mut result {
         if let Some(account) = account_map.get(&value.hash.to_vec()) {
-            value.context = ContextInfo {
+            value.tree_context = TreeContextInfo {
                 tree_type: account.tree_type as u16,
-                merkle_tree: SerializablePubkey::try_from(account.tree.clone())?,
+                tree: SerializablePubkey::try_from(account.tree.clone())?,
                 queue: SerializablePubkey::try_from(account.queue.clone())?,
                 cpi_context: None,
             };

--- a/src/api/method/get_queue_elements.rs
+++ b/src/api/method/get_queue_elements.rs
@@ -17,7 +17,7 @@ use crate::ingester::persist::get_multiple_compressed_leaf_proofs_by_indices;
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema, Default)]
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
 pub struct GetQueueElementsRequest {
-    pub merkle_tree: Hash,
+    pub tree: Hash,
     pub start_offset: Option<u64>,
     pub num_elements: u16,
     pub queue_type: u8,
@@ -37,7 +37,7 @@ pub struct GetQueueElementsResponseValue {
     pub root: Hash,
     pub leaf_index: u64,
     pub leaf: Hash,
-    pub merkle_tree: Hash,
+    pub tree: Hash,
     pub root_seq: u64,
     pub tx_hash: Option<Hash>,
     pub account_hash: Hash,
@@ -68,7 +68,7 @@ pub async fn get_queue_elements(
     }
 
     let mut query_condition =
-        Condition::all().add(accounts::Column::Tree.eq(request.merkle_tree.to_vec()));
+        Condition::all().add(accounts::Column::Tree.eq(request.tree.to_vec()));
 
     match queue_type {
         QueueType::BatchedInput => {
@@ -132,7 +132,7 @@ pub async fn get_queue_elements(
         (
             get_multiple_compressed_leaf_proofs_by_indices(
                 &tx,
-                SerializablePubkey::from(request.merkle_tree.0),
+                SerializablePubkey::from(request.tree.0),
                 indices,
             )
             .await?,
@@ -158,7 +158,7 @@ pub async fn get_queue_elements(
                 root: proof.root,
                 leaf_index: proof.leaf_index as u64,
                 leaf: proof.hash,
-                merkle_tree: Hash::from(proof.merkle_tree.0.to_bytes()),
+                tree: Hash::from(proof.merkle_tree.0.to_bytes()),
                 root_seq: proof.root_seq,
                 tx_hash,
                 account_hash,

--- a/src/api/method/get_transaction_with_compression_info.rs
+++ b/src/api/method/get_transaction_with_compression_info.rs
@@ -385,7 +385,7 @@ pub async fn get_transaction_helper_v2(
                         tree: x.account.tree,
                         queue: x.context.queue,
                         cpi_context: None,
-                        next_context: None,
+                        next_tree_context: None,
                     },
                 },
                 nullifier: x.context.nullifier.unwrap_or_default(),
@@ -412,7 +412,7 @@ pub async fn get_transaction_helper_v2(
                 tree: x.account.tree,
                 queue: x.context.queue,
                 cpi_context: None,
-                next_context: None,
+                next_tree_context: None,
             },
         })
         .collect::<Vec<AccountV2>>();

--- a/src/api/method/get_validity_proof/common.rs
+++ b/src/api/method/get_validity_proof/common.rs
@@ -131,7 +131,7 @@ impl From<GetValidityProofResponse> for GetValidityProofResponseV2 {
                             tree: SerializablePubkey::from(tree_info.tree),
                             queue: SerializablePubkey::from(tree_info.queue),
                             cpi_context: None,
-                            next_context: None,
+                            next_tree_context: None,
                         }
                     })
                     .collect(),
@@ -275,15 +275,15 @@ pub struct MerkleContextV2 {
     // nullifier_queue in legacy trees, output_queue in V2 trees.
     pub queue: SerializablePubkey,
     pub cpi_context: Option<SerializablePubkey>,
-    pub next_context: Option<ContextInfo>,
+    pub next_tree_context: Option<TreeContextInfo>,
 }
 
 #[derive(Serialize, Deserialize, ToSchema, Debug, Default, Clone, Eq, PartialEq)]
 #[serde(rename_all = "camelCase")]
 #[allow(non_snake_case)]
-pub struct ContextInfo {
+pub struct TreeContextInfo {
     pub tree_type: u16,
-    pub merkle_tree: SerializablePubkey,
+    pub tree: SerializablePubkey,
     pub queue: SerializablePubkey,
     pub cpi_context: Option<SerializablePubkey>,
 }

--- a/src/api/method/get_validity_proof/mod.rs
+++ b/src/api/method/get_validity_proof/mod.rs
@@ -3,9 +3,10 @@ mod v1;
 mod v2;
 
 pub use common::{
-    CompressedProof, CompressedProofWithContext, CompressedProofWithContextV2, ContextInfo,
+    CompressedProof, CompressedProofWithContext, CompressedProofWithContextV2,
     GetValidityProofRequest, GetValidityProofRequestDocumentation, GetValidityProofRequestV2,
     GetValidityProofResponse, GetValidityProofResponseV2, MerkleContextV2, RootIndex,
+    TreeContextInfo,
 };
 pub use v1::get_validity_proof;
 pub use v2::get_validity_proof_v2;

--- a/src/api/method/get_validity_proof/v2.rs
+++ b/src/api/method/get_validity_proof/v2.rs
@@ -117,7 +117,7 @@ pub async fn get_validity_proof_v2(
                 queue: SerializablePubkey::try_from_slice(account.queue.as_slice())
                     .unwrap_or(SerializablePubkey::default()),
                 cpi_context: None,
-                next_context: None,
+                next_tree_context: None,
             },
         );
         // proof by index has no root.

--- a/src/common/typedefs/account/v2.rs
+++ b/src/common/typedefs/account/v2.rs
@@ -72,7 +72,7 @@ impl TryFrom<Model> for AccountV2 {
                 tree: account.tree.try_into()?,
                 queue: account.queue.clone().try_into()?,
                 cpi_context: None,
-                next_context: None,
+                next_tree_context: None,
             },
         })
     }

--- a/src/ingester/persist/persisted_state_tree.rs
+++ b/src/ingester/persist/persisted_state_tree.rs
@@ -504,7 +504,7 @@ mod tests {
             root: Hash::try_from(ZERO_BYTES[31].to_vec()).unwrap(),
             leaf_index: test_leaf_index,
             hash: Hash::try_from(ZERO_BYTES[0].to_vec()).unwrap(),
-            merkle_tree: merkle_tree,
+            merkle_tree,
             root_seq: 0,
         };
 

--- a/src/openapi/mod.rs
+++ b/src/openapi/mod.rs
@@ -28,8 +28,8 @@ use crate::api::method::get_transaction_with_compression_info::{
     ClosedAccountWithOptionalTokenData,
 };
 use crate::api::method::get_validity_proof::{
-    CompressedProof, CompressedProofWithContext, CompressedProofWithContextV2, ContextInfo,
-    MerkleContextV2, RootIndex,
+    CompressedProof, CompressedProofWithContext, CompressedProofWithContextV2, MerkleContextV2,
+    RootIndex, TreeContextInfo,
 };
 use crate::api::method::utils::PaginatedSignatureInfoList;
 use crate::api::method::utils::SignatureInfo;
@@ -135,7 +135,7 @@ const JSON_CONTENT_TYPE: &str = "application/json";
     OwnerBalancesResponse,
     TokenBalanceListV2,
     MerkleContextV2,
-    ContextInfo,
+    TreeContextInfo,
     GetCompressedAccountProofResponseValueV1,
     GetCompressedAccountProofResponseValueV2,
     GetMultipleCompressedAccountProofsResponseValue

--- a/tests/integration_tests/batched_state_tree_tests.rs
+++ b/tests/integration_tests/batched_state_tree_tests.rs
@@ -128,7 +128,7 @@ async fn test_batched_tree_transactions(
             let get_queue_elements_result = setup
                 .api
                 .get_queue_elements(GetQueueElementsRequest {
-                    merkle_tree: merkle_tree_pubkey.to_bytes().into(),
+                    tree: merkle_tree_pubkey.to_bytes().into(),
                     start_offset: None,
                     queue_type: QueueType::BatchedOutput as u8,
                     num_elements: 100,
@@ -154,7 +154,7 @@ async fn test_batched_tree_transactions(
             let get_queue_elements_result = setup
                 .api
                 .get_queue_elements(GetQueueElementsRequest {
-                    merkle_tree: merkle_tree_pubkey.to_bytes().into(),
+                    tree: merkle_tree_pubkey.to_bytes().into(),
                     start_offset: None,
                     queue_type: QueueType::BatchedInput as u8,
                     num_elements: 100,
@@ -228,7 +228,7 @@ async fn test_batched_tree_transactions(
         let pre_output_queue_elements = setup
             .api
             .get_queue_elements(GetQueueElementsRequest {
-                merkle_tree: merkle_tree_pubkey.to_bytes().into(),
+                tree: merkle_tree_pubkey.to_bytes().into(),
                 start_offset: None,
                 queue_type: QueueType::BatchedOutput as u8,
                 num_elements: 100,
@@ -238,7 +238,7 @@ async fn test_batched_tree_transactions(
         let pre_input_queue_elements = setup
             .api
             .get_queue_elements(GetQueueElementsRequest {
-                merkle_tree: merkle_tree_pubkey.to_bytes().into(),
+                tree: merkle_tree_pubkey.to_bytes().into(),
                 start_offset: None,
                 queue_type: QueueType::BatchedInput as u8,
                 num_elements: 100,
@@ -257,7 +257,7 @@ async fn test_batched_tree_transactions(
         let post_output_queue_elements = setup
             .api
             .get_queue_elements(GetQueueElementsRequest {
-                merkle_tree: merkle_tree_pubkey.to_bytes().into(),
+                tree: merkle_tree_pubkey.to_bytes().into(),
                 start_offset: None,
                 queue_type: QueueType::BatchedOutput as u8,
                 num_elements: 100,
@@ -267,7 +267,7 @@ async fn test_batched_tree_transactions(
         let post_input_queue_elements = setup
             .api
             .get_queue_elements(GetQueueElementsRequest {
-                merkle_tree: merkle_tree_pubkey.to_bytes().into(),
+                tree: merkle_tree_pubkey.to_bytes().into(),
                 start_offset: None,
                 queue_type: QueueType::BatchedInput as u8,
                 num_elements: 100,
@@ -397,7 +397,7 @@ async fn test_batched_tree_transactions(
     let get_queue_elements_result = setup
         .api
         .get_queue_elements(GetQueueElementsRequest {
-            merkle_tree: merkle_tree_pubkey.to_bytes().into(),
+            tree: merkle_tree_pubkey.to_bytes().into(),
             start_offset: None,
             queue_type: QueueType::BatchedOutput as u8,
             num_elements: 100,
@@ -413,7 +413,7 @@ async fn test_batched_tree_transactions(
     let get_queue_elements_result = setup
         .api
         .get_queue_elements(GetQueueElementsRequest {
-            merkle_tree: merkle_tree_pubkey.to_bytes().into(),
+            tree: merkle_tree_pubkey.to_bytes().into(),
             start_offset: None,
             queue_type: QueueType::BatchedInput as u8,
             num_elements: 100,


### PR DESCRIPTION
* `MerkleContextV2` merkle_tree -> tree
* `MerkleContextV2` next_context -> next_tree_context


* `ContextInfo` -> `TreeContextInfo`


* `GetQueueElementRequest` merkle_tree -> tree
* `GetQueueElementResponseValue` merkle_tree -> tree  