### PR TITLE
Add `getTreeMetadata` API endpoint

### DIFF
--- a/src/api/api.rs
+++ b/src/api/api.rs
@@ -81,6 +81,9 @@ use crate::api::method::get_multiple_compressed_account_proofs::{
 use crate::api::method::get_queue_elements::{
     get_queue_elements, GetQueueElementsRequest, GetQueueElementsResponse,
 };
+use crate::api::method::get_queue_tree_mapping::{
+    get_queue_tree_mapping, QueueTreeMappingResponse,
+};
 use crate::api::method::get_validity_proof::{
     get_validity_proof, get_validity_proof_v2, GetValidityProofRequest,
     GetValidityProofRequestDocumentation, GetValidityProofRequestV2, GetValidityProofResponse,
@@ -388,6 +391,10 @@ impl PhotonApi {
         get_batch_address_update_info(self.db_conn.as_ref(), request).await
     }
 
+    pub async fn get_queue_tree_mapping(&self) -> Result<QueueTreeMappingResponse, PhotonApiError> {
+        Ok(get_queue_tree_mapping().await)
+    }
+
     pub fn method_api_specs() -> Vec<OpenApiSpec> {
         vec![
             OpenApiSpec {
@@ -576,6 +583,11 @@ impl PhotonApi {
                 name: "getIndexerSlot".to_string(),
                 request: None,
                 response: UnsignedInteger::schema().1,
+            },
+            OpenApiSpec {
+                name: "getQueueTreeMapping".to_string(),
+                request: None,
+                response: QueueTreeMappingResponse::schema().1,
             },
         ]
     }

--- a/src/api/method/get_queue_tree_mapping.rs
+++ b/src/api/method/get_queue_tree_mapping.rs
@@ -1,0 +1,45 @@
+use crate::ingester::parser::tree_info::{TreeInfo, QUEUE_TREE_MAPPING};
+use light_compressed_account::TreeType;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use utoipa::ToSchema;
+
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub struct SerializableTreeInfo {
+    pub tree: String,
+    pub queue: String,
+    pub height: u32,
+    pub tree_type: String,
+}
+
+impl From<&TreeInfo> for SerializableTreeInfo {
+    fn from(info: &TreeInfo) -> Self {
+        SerializableTreeInfo {
+            tree: info.tree.to_string(),
+            queue: info.queue.to_string(),
+            height: info.height,
+            tree_type: match info.tree_type {
+                TreeType::StateV1 => "StateV1".to_string(),
+                TreeType::StateV2 => "StateV2".to_string(),
+                TreeType::AddressV1 => "AddressV1".to_string(),
+                TreeType::AddressV2 => "AddressV2".to_string(),
+                _ => "Unknown".to_string(),
+            },
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub struct QueueTreeMappingResponse {
+    pub mapping: HashMap<String, SerializableTreeInfo>,
+}
+
+pub async fn get_queue_tree_mapping() -> QueueTreeMappingResponse {
+    let mut mapping = HashMap::new();
+
+    for (key, value) in QUEUE_TREE_MAPPING.iter() {
+        mapping.insert(key.clone(), SerializableTreeInfo::from(value));
+    }
+
+    QueueTreeMappingResponse { mapping }
+}

--- a/src/api/method/mod.rs
+++ b/src/api/method/mod.rs
@@ -25,5 +25,6 @@ pub mod get_transaction_with_compression_info;
 pub mod get_validity_proof;
 
 pub mod get_batch_address_update_info;
+pub mod get_queue_tree_mapping;
 
 pub mod utils;

--- a/src/api/rpc_server.rs
+++ b/src/api/rpc_server.rs
@@ -188,6 +188,11 @@ fn build_rpc_module(api_and_indexer: PhotonApi) -> Result<RpcModule<PhotonApi>, 
         api.get_indexer_slot().await.map_err(Into::into)
     })?;
 
+    module.register_async_method("getTreeMetadata", |_rpc_params, rpc_context| async move {
+        let api = rpc_context.as_ref();
+        api.get_queue_tree_mapping().await.map_err(Into::into)
+    })?;
+
     module.register_async_method("getQueueElements", |rpc_params, rpc_context| async move {
         let api = rpc_context.as_ref();
         let payload = rpc_params.parse()?;


### PR DESCRIPTION
Implement a new API method `getTreeMetadata` to retrieve metadata about queue-tree mappings.