### PR TITLE
chore:  rename pagination params

### DIFF
--- a/tests/integration_tests/batched_address_tree_tests.rs
+++ b/tests/integration_tests/batched_address_tree_tests.rs
@@ -165,8 +165,8 @@ async fn run_batched_address_test(
         .api
         .get_batch_address_update_info(GetBatchAddressUpdateInfoRequest {
             tree: address_tree_pubkey.to_bytes().into(),
-            start_offset: None,
-            batch_size: 100,
+            start_queue_index: None,
+            limit: 100,
         })
         .await
         .expect("Failed to get address queue elements before batch update");
@@ -213,8 +213,8 @@ async fn run_batched_address_test(
         .api
         .get_batch_address_update_info(GetBatchAddressUpdateInfoRequest {
             tree: address_tree_pubkey.to_bytes().into(),
-            start_offset: None,
-            batch_size: 100,
+            start_queue_index: None,
+            limit: 100,
         })
         .await
         .expect("Failed to get address queue elements after batch update");

--- a/tests/integration_tests/batched_state_tree_tests.rs
+++ b/tests/integration_tests/batched_state_tree_tests.rs
@@ -161,9 +161,9 @@ async fn test_batched_tree_transactions(
                 .api
                 .get_queue_elements(GetQueueElementsRequest {
                     tree: merkle_tree_pubkey.to_bytes().into(),
-                    start_offset: None,
+                    start_queue_index: None,
                     queue_type: QueueType::OutputStateV2 as u8,
-                    num_elements: 100,
+                    limit: 100,
                 })
                 .await
                 .unwrap();
@@ -187,9 +187,9 @@ async fn test_batched_tree_transactions(
                 .api
                 .get_queue_elements(GetQueueElementsRequest {
                     tree: merkle_tree_pubkey.to_bytes().into(),
-                    start_offset: None,
+                    start_queue_index: None,
                     queue_type: QueueType::InputStateV2 as u8,
-                    num_elements: 100,
+                    limit: 100,
                 })
                 .await
                 .unwrap();
@@ -274,9 +274,9 @@ async fn test_batched_tree_transactions(
             .api
             .get_queue_elements(GetQueueElementsRequest {
                 tree: merkle_tree_pubkey.to_bytes().into(),
-                start_offset: None,
+                start_queue_index: None,
                 queue_type: QueueType::OutputStateV2 as u8,
-                num_elements: 100,
+                limit: 100,
             })
             .await
             .unwrap();
@@ -284,9 +284,9 @@ async fn test_batched_tree_transactions(
             .api
             .get_queue_elements(GetQueueElementsRequest {
                 tree: merkle_tree_pubkey.to_bytes().into(),
-                start_offset: None,
+                start_queue_index: None,
                 queue_type: QueueType::InputStateV2 as u8,
-                num_elements: 100,
+                limit: 100,
             })
             .await
             .unwrap();
@@ -303,9 +303,9 @@ async fn test_batched_tree_transactions(
             .api
             .get_queue_elements(GetQueueElementsRequest {
                 tree: merkle_tree_pubkey.to_bytes().into(),
-                start_offset: None,
+                start_queue_index: None,
                 queue_type: QueueType::OutputStateV2 as u8,
-                num_elements: 100,
+                limit: 100,
             })
             .await
             .unwrap();
@@ -313,9 +313,9 @@ async fn test_batched_tree_transactions(
             .api
             .get_queue_elements(GetQueueElementsRequest {
                 tree: merkle_tree_pubkey.to_bytes().into(),
-                start_offset: None,
+                start_queue_index: None,
                 queue_type: QueueType::InputStateV2 as u8,
-                num_elements: 100,
+                limit: 100,
             })
             .await
             .unwrap();
@@ -441,9 +441,9 @@ async fn test_batched_tree_transactions(
         .api
         .get_queue_elements(GetQueueElementsRequest {
             tree: merkle_tree_pubkey.to_bytes().into(),
-            start_offset: None,
+            start_queue_index: None,
             queue_type: QueueType::OutputStateV2 as u8,
-            num_elements: 100,
+            limit: 100,
         })
         .await
         .unwrap();
@@ -457,9 +457,9 @@ async fn test_batched_tree_transactions(
         .api
         .get_queue_elements(GetQueueElementsRequest {
             tree: merkle_tree_pubkey.to_bytes().into(),
-            start_offset: None,
+            start_queue_index: None,
             queue_type: QueueType::InputStateV2 as u8,
-            num_elements: 100,
+            limit: 100,
         })
         .await
         .unwrap();


### PR DESCRIPTION

## Overview
1. rename `start_offset` -> `start_queue_index`
2. rename `batch_size` -> `limit`
3. rename `num_elements` -> `limit`

