### PR TITLE
chore: bump v

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4533,7 +4533,7 @@ dependencies = [
 
 [[package]]
 name = "photon-indexer"
-version = "0.50.0"
+version = "0.51.0"
 dependencies = [
  "anchor-lang 0.29.0",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ name = "photon-indexer"
 publish = true
 readme = "README.md"
 repository = "https://github.com/helius-labs/photon"
-version = "0.50.0"
+version = "0.51.0"
 
 [[bin]]
 name = "photon"


### PR DESCRIPTION
required for cli release